### PR TITLE
Collapsing checkboxes now align correctly

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -347,6 +347,11 @@ body:not(.default-font-color) mark em {
   color: var(--text-faint);
 }
 
+/* Collapsing list checkboxes alignment */
+.markdown-rendered .list-collapse-indicator {
+    margin-left: -4em;
+}
+
 /* Image card */
 img {
   border-radius: 4px;


### PR DESCRIPTION
When checkboxes are part of a collapsing list, they don't align correctly.

**Before:**
https://www.dropbox.com/s/51mhu1h5f0vfsvf/before.png?dl=0

**After:**
﻿https://www.dropbox.com/s/rqryyg3axesyb60/after.png?dl=0